### PR TITLE
Align SLF4J version with sisu.plexus

### DIFF
--- a/org.eclipse.sisu.inject.tests/pom.xml
+++ b/org.eclipse.sisu.inject.tests/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.4</version>
+      <version>1.6.6</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Was 1.6.4 here vs 1.6.6 in sisu.plexus, went
with higher.