### PR TITLE
Cache binding lookups for single bean providers

### DIFF
--- a/org.eclipse.sisu.inject/src/org/eclipse/sisu/wire/BeanProviders.java
+++ b/org.eclipse.sisu.inject/src/org/eclipse/sisu/wire/BeanProviders.java
@@ -167,7 +167,7 @@ final class BeanProviders
      */
     public <V> Provider<V> placeholderOf( final Key<V> key )
     {
-        return new PlaceholderBeanProvider<V>( locator, key );
+        return new PlaceholderBeanProvider<V>( this, key );
     }
 
     /**

--- a/org.eclipse.sisu.inject/src/org/eclipse/sisu/wire/BeanProviders.java
+++ b/org.eclipse.sisu.inject/src/org/eclipse/sisu/wire/BeanProviders.java
@@ -155,9 +155,16 @@ final class BeanProviders
         final Provider<Iterable<? extends BeanEntry<Annotation, V>>> beanEntries = beanEntriesOf( key );
         return new Provider<V>()
         {
+            private volatile Iterable<? extends BeanEntry<?, V>> cachedLookup;
+
             public V get()
             {
-                return firstOf( beanEntries.get() );
+                if ( null == cachedLookup )
+                {
+                    cachedLookup = beanEntries.get();
+                }
+                final Iterator<? extends BeanEntry<?, V>> itr = cachedLookup.iterator();
+                return itr.hasNext() ? itr.next().getProvider().get() : null;
             }
         };
     }
@@ -168,14 +175,5 @@ final class BeanProviders
     public <V> Provider<V> placeholderOf( final Key<V> key )
     {
         return new PlaceholderBeanProvider<V>( this, key );
-    }
-
-    /**
-     * Selects first bean from the sequence; or null if none is available.
-     */
-    public static <V> V firstOf( final Iterable<? extends Entry<?, V>> entries )
-    {
-        final Iterator<? extends Entry<?, V>> itr = entries.iterator();
-        return itr.hasNext() ? itr.next().getValue() : null;
     }
 }


### PR DESCRIPTION
Previously every call to `provider.get()` for a Sisu-managed `Provider<T>` resulted in a new binding lookup.

These extra lookups are unnecessary because Sisu will automatically update live lookups as injectors come and go. This is done to support dynamic maps/lists of beans, but it does mean we can cache binding lookups and re-use them for single providers as long as we only get instances via `BeanEntry.getProvider().get()`.

Note: we can't use `BeanEntry.getValue()` when re-using binding lookups because it caches the instance, whereas here we always want to return a fresh bean instance.