### PR TITLE
Allow Main to boot with extra bindings

### DIFF
--- a/org.eclipse.sisu.inject/src/org/eclipse/sisu/launch/Main.java
+++ b/org.eclipse.sisu.inject/src/org/eclipse/sisu/launch/Main.java
@@ -67,10 +67,24 @@ public final class Main
         return boot( System.getProperties(), args ).getInstance( type );
     }
 
+    public static <T> T boot( final Class<T> type, final String[] args, final Module... bindings )
+    {
+        return boot( System.getProperties(), args, bindings ).getInstance( type );
+    }
+
     public static Injector boot( final Map<?, ?> properties, final String... args )
     {
+        return boot( properties, args, new Module[0] );
+    }
+
+    public static Injector boot( final Map<?, ?> properties, final String[] args, final Module... bindings )
+    {
+        final Module[] modules = new Module[bindings.length + 1];
+        System.arraycopy( bindings, 0, modules, 1, bindings.length );
+        modules[0] = new Main( properties, args );
+
         final BeanScanning scanning = BeanScanning.select( properties );
-        final Module app = wire( scanning, new Main( properties, args ) );
+        final Module app = wire( scanning, modules );
         final Injector injector = Guice.createInjector( app );
 
         return injector;


### PR DESCRIPTION
In several cases it would be convenient to be able to do `Main.boot(MyApp.class, args, myBindings).run()` for a CLI app, i.e. provide additional bindings for the application. This adds the necessary utilities to do so.