### PR TITLE
3.7 is not an officially supported version therefore specify 3.8 instead

### DIFF
--- a/org.eclipse.sisu.inject/build.target
+++ b/org.eclipse.sisu.inject/build.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.7"?>
+<?pde version="3.8"?>
 <target name="org.eclipse.sisu.inject" sequenceNumber="0">
 	<locations>
 		<location type="Maven" includeSource="true">


### PR DESCRIPTION
Using 3.7 leads to the following warning in recent Eclipse:
"The target definition "org.eclipse.sisu.plexus" contains an unexpected
PDE version entry "3.7". The target definition may have been created in
a newer version of Eclipse and some contents may not be read correctly."