### PR TITLE
Go back to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   </ciManagement>
 
   <properties>
-    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.release>7</maven.compiler.release>
     <!-- Set to same version as release target for consistency -->
     <maven.compiler.source>1.${maven.compiler.release}</maven.compiler.source>
     <maven.compiler.target>1.${maven.compiler.release}</maven.compiler.target>


### PR DESCRIPTION
Given we do not use Java 8 features yet, IMHO let's step back and do M2 release w/ Java7, as that would allow all Maven versions (including possible release of 3.8.x line) to grab the new sisu version.

On they way to final 1.0.0 release we may still choose to go Java 8 (my preference would be that).