### PR TITLE
Create a 'no_asm' jar at release time which doesn't embed ASM

### DIFF
--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -395,4 +395,46 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <!--
+                   | Create 'no_asm' jar which doesn't embed ASM and refers to the original org.objectweb.asm package.
+                  -->
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>no_asm</shadedClassifierName>
+                  <filters>
+                    <filter>
+                      <artifact>org.eclipse.sisu:org.eclipse.sisu.inject</artifact>
+                      <excludes>
+                        <exclude>org/eclipse/sisu/space/asm/**</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                  <relocations>
+                    <relocation>
+                      <pattern>org.eclipse.sisu.space.asm</pattern>
+                      <shadedPattern>org.objectweb.asm</shadedPattern>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -429,6 +429,13 @@
                       <shadedPattern>org.objectweb.asm</shadedPattern>
                     </relocation>
                   </relocations>
+                  <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <manifestEntries>
+                        <DynamicImport-Package>org.objectweb.asm</DynamicImport-Package>
+                      </manifestEntries>
+                    </transformer>
+                  </transformers>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,11 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>


### PR DESCRIPTION
and instead refers to the original org.objectweb.asm package.

This is provided as a convenience for users that wish to use a different version of ASM between releases of Sisu-Inject.