### PR TITLE
Update workflow to run on Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ '11', '17', '20' ]
+        java: [ '11', '17', '21-ea' ]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Have to use `21-ea` for now as explained in https://github.com/actions/setup-java/issues/541#issuecomment-1734996427