### PR TITLE
Rename release profile

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+# Releasing Sisu
+
+## Maven
+
+It should be the "usual" Maven release:
+* `mvn release:prepare`
+* `mvn release:perform`
+* project uses https://oss.sonatype.org/ to stage (manual step: close and release staging repository)
+
+## Site
+
+TBD

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,16 @@
 
 ## Maven
 
-It should be the "usual" Maven release:
+Note: Build uses latest `maven-gpg-plugin` and is getting rid "old bad practices" of storing sensitive information in
+any Maven configuration file. Hence, on Workstations, users are recommended to have GPG Agent set up and running,
+as plugin will make use of it to get the sensitive information. On unattended releases, the use of
+BouncyCastle signer is recommended, and use environment variables `MAVEN_GPG_KEY` and `MAVEN_GPG_PASSPHRASE` 
+to pass over the key material and the passphrase to `maven-gpg-plugin`.
+See [maven-gpg-plugin site](https://maven.apache.org/plugins/maven-gpg-plugin/usage.html) for more information.
+
+### Release steps
+
+The "usual" Maven release:
 * `mvn release:prepare`
 * `mvn release:perform`
 * project uses https://oss.sonatype.org/ to stage (manual step: close and release staging repository)

--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -456,7 +456,7 @@
 
   <profiles>
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>sisu-release</id>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>-Psonatype-oss-release</arguments>
+            <arguments>-Psisu-release</arguments>
             <localCheckout>true</localCheckout>
             <pushChanges>false</pushChanges>
             <scmCommentPrefix>|</scmCommentPrefix>
@@ -570,7 +570,7 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
       </build>
     </profile>
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>sisu-release</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
As we dumped nx2 staging plugin, rename the profile ID to something more logical: "sisu-release".