### PR TITLE
Fix jacoco + code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [ "${{ matrix.isMainBuildEnv }}" = "true" ]; then
             echo "SONAR_TOKEN=${{ secrets.SONAR_TOKEN }}" >> $GITHUB_ENV
-            echo "MVN_ADDITIONAL_OPTS=org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}" >> $GITHUB_ENV
+            echo "MVN_ADDITIONAL_OPTS=org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }} -Pcode-coverage" >> $GITHUB_ENV
             echo "GIT_FETCH_DEPTH=0" >> $GITHUB_ENV # Shallow clones should be disabled for a better relevancy of analysis
           else
             echo "MVN_ADDITIONAL_OPTS=" >> $GITHUB_ENV

--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -423,10 +423,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 
@@ -474,6 +470,17 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>code-coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/org.eclipse.sisu.plexus/pom.xml
+++ b/org.eclipse.sisu.plexus/pom.xml
@@ -439,11 +439,21 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>code-coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/org.eclipse.sisu.plexus/pom.xml
+++ b/org.eclipse.sisu.plexus/pom.xml
@@ -441,7 +441,6 @@
       </plugin>
     </plugins>
   </build>
-
   <profiles>
     <profile>
       <id>code-coverage</id>
@@ -455,5 +454,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,13 @@
     <!-- Source headers -->
     <sisu.licenseHeader>https://raw.githubusercontent.com/eclipse-sisu/sisu-project/main/license-header-epl2.txt</sisu.licenseHeader>
     <sisu.licenseYear>${project.inceptionYear}-2024</sisu.licenseYear>
+
+    <!-- Jacoco and Sonar -->
     <jacoco.argLine />
+    <sonar.coverage.jacoco.xmlReportPaths>
+      ${maven.multiModuleProjectDirectory}/org.eclipse.sisu.inject/target/site/jacoco/jacoco.xml,
+      ${maven.multiModuleProjectDirectory}/org.eclipse.sisu.plexus/target/site/jacoco/jacoco.xml
+    </sonar.coverage.jacoco.xmlReportPaths>
 
     <!-- Versions -->
     <mavenRuntimeVersion>3.2.5</mavenRuntimeVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -674,16 +674,5 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>code-coverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <!-- Source headers -->
     <sisu.licenseHeader>https://raw.githubusercontent.com/eclipse-sisu/sisu-project/main/license-header-epl2.txt</sisu.licenseHeader>
     <sisu.licenseYear>${project.inceptionYear}-2024</sisu.licenseYear>
+    <jacoco.argLine />
 
     <!-- Versions -->
     <mavenRuntimeVersion>3.2.5</mavenRuntimeVersion>


### PR DESCRIPTION
There was a mix: profile "code-coverage" that was never activated but added coverage to ALL modules, while inject and plexus had their own plugin executions set that ran always.