### PR TITLE
Enable code coverage again for all modules

### DIFF
--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -309,7 +309,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <argLine>-Xmx64m --add-opens java.base/java.lang=ALL-UNNAMED @{jacoco.argLine}</argLine>
+          <argLine>-Xmx64m --add-opens java.base/java.lang=ALL-UNNAMED @{argLine}</argLine>
           <classpathDependencyExcludes>
             <classpathDependencyExclude>com.google.guava:guava</classpathDependencyExclude>
             <classpathDependencyExclude>com.google.inject:guice</classpathDependencyExclude>
@@ -470,17 +470,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>code-coverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/org.eclipse.sisu.plexus/pom.xml
+++ b/org.eclipse.sisu.plexus/pom.xml
@@ -297,7 +297,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <argLine>-Xmx64m @{jacoco.argLine}</argLine>
+          <argLine>-Xmx64m @{argLine}</argLine>
           <classpathDependencyExcludes>
             <classpathDependencyExclude>com.google.guava:guava</classpathDependencyExclude>
             <classpathDependencyExclude>com.google.inject:guice</classpathDependencyExclude>
@@ -441,17 +441,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>code-coverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,13 +117,6 @@
     <sisu.licenseHeader>https://raw.githubusercontent.com/eclipse-sisu/sisu-project/main/license-header-epl2.txt</sisu.licenseHeader>
     <sisu.licenseYear>${project.inceptionYear}-2024</sisu.licenseYear>
 
-    <!-- Jacoco and Sonar -->
-    <jacoco.argLine />
-    <sonar.coverage.jacoco.xmlReportPaths>
-      ${maven.multiModuleProjectDirectory}/org.eclipse.sisu.inject/target/site/jacoco/jacoco.xml,
-      ${maven.multiModuleProjectDirectory}/org.eclipse.sisu.plexus/target/site/jacoco/jacoco.xml
-    </sonar.coverage.jacoco.xmlReportPaths>
-
     <!-- Versions -->
     <mavenRuntimeVersion>3.2.5</mavenRuntimeVersion>
     <mavenBuildVersion>3.6.3</mavenBuildVersion>
@@ -131,6 +124,8 @@
     <mavenPluginToolsVersion>3.13.1</mavenPluginToolsVersion>
     <!-- Note: this version is used in tests, to update embedded asm use bin/update_asm.sh -->
     <asmVersion>9.7</asmVersion>
+    <!-- define empty, as jacoco is only conditionally executed (https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html) -->
+    <argLine />
   </properties>
 
   <dependencyManagement>
@@ -677,6 +672,18 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- not all sub modules have tests yet, but those additional executions don't do any harm -->
+    <profile>
+      <id>code-coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Overhead should be neglectable for modules not having tests yet Rely on Sonarcloud default paths for discovering jacoco reports (works fine even for submodules)