### PR TITLE
Use default property for the jacoco agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,11 +430,11 @@ Bundle-DocURL: http://www.eclipse.org/sisu/
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.12</version>
           <configuration>
-            <propertyName>jacoco.argLine</propertyName>
             <excludes>
               <exclude>**/asm/*</exclude>
               <exclude>Incomplete*</exclude>
             </excludes>
+            <append>true</append>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Always append jacoco execution reports because of multiple m-surefire-p executions (which may all contribute to the coverage)