### PR TITLE
Call TypeAwareExpressionEvaluator.evaluate(String,Class) if available

### DIFF
--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/basic/EnumConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/basic/EnumConverter.java
@@ -39,7 +39,7 @@ public class EnumConverter
                 + "' must not contain child elements" );
         }
 
-        Object result = fromExpression( configuration, evaluator );
+        Object result = fromExpression( configuration, evaluator, type, false );
         if ( result instanceof String )
         {
             try

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/ArrayConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/ArrayConverter.java
@@ -49,7 +49,7 @@ public class ArrayConverter
                                      final ConfigurationListener listener )
         throws ComponentConfigurationException
     {
-        final Object value = fromExpression( configuration, evaluator );
+        final Object value = fromExpression( configuration, evaluator, type, false );
         if ( type.isInstance( value ) )
         {
             return value;

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/CollectionConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/CollectionConverter.java
@@ -53,7 +53,7 @@ public class CollectionConverter
                                      final ConfigurationListener listener )
         throws ComponentConfigurationException
     {
-        final Object value = fromExpression( configuration, evaluator );
+        final Object value = fromExpression( configuration, evaluator, type, false );
         if ( type.isInstance( value ) )
         {
             return value;

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/MapConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/MapConverter.java
@@ -60,13 +60,13 @@ public class MapConverter
         try
         {
             final Map<Object, Object> map = instantiateMap( configuration, type, loader );
-            final Type elementType = findElementType( typeArguments );
+            final Type elementType = findElementClass( typeArguments );
             if ( Object.class == elementType || String.class == elementType )
             {
                 for ( int i = 0, size = configuration.getChildCount(); i < size; i++ )
                 {
                     final PlexusConfiguration element = configuration.getChild( i );
-                    map.put( element.getName(), fromExpression( element, evaluator ) );
+                    map.put( element.getName(), fromExpression( element, evaluator, (Class<?>)elementType ) );
                 }
                 return map;
             }
@@ -96,7 +96,7 @@ public class MapConverter
                 // TEMP: remove when http://jira.codehaus.org/browse/MSHADE-168 is fixed
                 catch ( final ComponentConfigurationException e )
                 {
-                    elementValue = fromExpression( element, evaluator );
+                    elementValue = fromExpression( element, evaluator, type );
 
                     Logs.warn( "Map in " + enclosingType + " declares value type as: {} but saw: {} at runtime",
                                elementType, null != elementValue ? elementValue.getClass() : null );
@@ -132,7 +132,7 @@ public class MapConverter
         return (Map<Object, Object>) impl;
     }
 
-    private static Type findElementType( final Type[] typeArguments )
+    private static Type findElementClass( final Type[] typeArguments )
     {
         if ( null != typeArguments && typeArguments.length > 1 )
         {
@@ -140,4 +140,5 @@ public class MapConverter
         }
         return Object.class;
     }
+
 }

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/ObjectWithFieldsConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/ObjectWithFieldsConverter.java
@@ -40,7 +40,8 @@ public class ObjectWithFieldsConverter
                                      final ExpressionEvaluator evaluator, final ConfigurationListener listener )
         throws ComponentConfigurationException
     {
-        final Object value = fromExpression( configuration, evaluator );
+        // no type enforcement as also accepting string types used in the custom types constructor
+        final Object value = fromExpression( configuration, evaluator, type, false );
         if ( type.isInstance( value ) )
         {
             return value;

--- a/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/PropertiesConverter.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/codehaus/plexus/component/configurator/converters/composite/PropertiesConverter.java
@@ -48,7 +48,7 @@ public class PropertiesConverter
                 final PlexusConfiguration element = configuration.getChild( i );
                 if ( element.getChildCount() > 0 )
                 {
-                    final Object name = fromExpression( element.getChild( "name" ), evaluator );
+                    final Object name = fromExpression( element.getChild( "name" ), evaluator, String.class, false );
                     setProperty( properties, name, element.getChild( "value" ), evaluator );
                 }
                 else
@@ -91,7 +91,7 @@ public class PropertiesConverter
         final String key = null != name ? name.toString() : null;
         if ( null != key )
         {
-            final Object value = fromExpression( valueConfiguration, evaluator );
+            final Object value = fromExpression( valueConfiguration, evaluator, String.class, false );
             properties.setProperty( key, null != value ? value.toString() : "" );
         }
         else


### PR DESCRIPTION
Only enforce types in some places (where conversion afterwards never happens)

This closes #160