### PR TITLE
Publish via Sonatype Central Porta (alt proposal)

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>eu.maveniverse.maven.njord</groupId>
         <artifactId>extension</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.3</version>
     </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>eu.maveniverse.maven.njord</groupId>
         <artifactId>extension</artifactId>
-        <version>0.3.3</version>
+        <version>0.4.0</version>
     </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>eu.maveniverse.maven.njord</groupId>
         <artifactId>extension</artifactId>
-        <version>0.4.0</version>
+        <version>0.4.1</version>
     </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.njord</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.2.0</version>
+    </extension>
+</extensions>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,14 +27,20 @@ uses [Maveniverse Njord](https://github.com/maveniverse/njord) extension. Check 
 
 Follow these steps to set up yourself to publish to Central Portal:
 
-1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account.
-2. Edit your settings and add following server entry:
+1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account. Add those account
+   **to the service we use to publish: Sonatype Central Portal** as this:
    ```xml
     <server>
-      <id>sonatype-cp-service</id>
+      <id>sonatype-cp</id>
       <!-- Create TOKEN1/TOKEN2 with Portal Service -->
       <username>$TOKEN1</username>
       <password>$TOKEN2</password>
+    </server>
+   ```
+2. Sisu POM distribution management servers setup, edit your settings and add following server entry:
+   ```xml
+    <server>
+      <id>sonatype-cp-service</id>
       <configuration>
         <!-- Using Sonatype Central Portal publisher -->
         <njord.publisher>sonatype-cp</njord.publisher>
@@ -50,10 +56,12 @@ Follow these steps to set up yourself to publish to Central Portal:
      <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
    </pluginGroups>
    ```
+   The POM `project/distributionManagement/repository/id` named server is now "redirected" to `sonatype-cp` server 
+   (and publishing service).
 3. Perform release "as usual" (execute `mvn release:prepare` followed by `mvn release:perform`)
 4. If build ended OK, you will have locally staged release, use `mvn njord:list` to check store name.
 5. If needed, verify staging content using `mvn njord:list-content -Dstore=$storeName`
-6. If all okay, publish the staged store to Sonatype Central Portal `mvn njord:publish` (by default will publish to `sonatype-cp` and will figure out store. If override needed, use `-Dstore=$storeName -Dtarget=sonatype-cp`)
+6. If all okay, publish the staged store to Sonatype Central Portal `mvn publish` (by default will publish to `sonatype-cp` and will figure out store. If override needed, use `-Dstore=$storeName -Dtarget=sonatype-cp`)
 
 ## Site
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,8 +45,9 @@ Follow these steps to set up yourself to publish to Central Portal:
         <!-- Using Sonatype Central Portal publisher -->
         <njord.publisher>sonatype-cp</njord.publisher>
         <!-- Releases are staged locally (if omitted, would go directly to URL as per POM) -->
-        <!-- Snapshots goes directly to URL as per POM -->
         <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+        <!-- Snapshots are staged locally (if omitted, would go directly to URL as per POM) -->
+        <njord.snapshotUrl>njord:template:snapshot-sca</njord.snapshotUrl>
       </configuration>
     </server>
    ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,10 +30,18 @@ Follow these steps to set up yourself to publish to Central Portal:
 1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account.
 2. Edit your settings and add following server entry:
    ```xml
-   <server>
-      <id>sonatype-cp</id>
-      <username>{tokenusername}</username>
-      <password>{tokenpassword}</password>
+    <server>
+      <id>sonatype-cp-service</id>
+      <!-- Create TOKEN1/TOKEN2 with Portal Service -->
+      <username>$TOKEN1</username>
+      <password>$TOKEN2</password>
+      <configuration>
+        <!-- Using Sonatype Central Portal publisher -->
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <!-- Releases are staged locally (if omitted, would go directly to URL as per POM) -->
+        <!-- Snapshots goes directly to URL as per POM -->
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+      </configuration>
     </server>
    ```
    while here, another good change for settings is this:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,8 +27,8 @@ uses [Maveniverse Njord](https://github.com/maveniverse/njord) extension. Check 
 
 Follow these steps to set up yourself to publish to Central Portal:
 
-1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account. Add those account
-   **to the service we use to publish: Sonatype Central Portal** as this:
+1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account. Add those tokens
+   **to the service/server we use to publish**, the Sonatype Central Portal as this in `settings.xml`:
    ```xml
     <server>
       <id>sonatype-cp</id>
@@ -37,7 +37,7 @@ Follow these steps to set up yourself to publish to Central Portal:
       <password>$TOKEN2</password>
     </server>
    ```
-2. Sisu POM distribution management servers setup, edit your settings and add following server entry:
+2. Sisu POM distribution management servers setup, add to your `settings.xml` following server entry:
    ```xml
     <server>
       <id>sonatype-cp-service</id>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,17 +13,39 @@ BouncyCastle signer is recommended, and use environment variables `MAVEN_GPG_KEY
 to pass over the key material and the passphrase to `maven-gpg-plugin`.
 See [maven-gpg-plugin site](https://maven.apache.org/plugins/maven-gpg-plugin/usage.html) for more information.
 
-### Release steps
+## Before release
 
 **Prerequisites:**
 * deploy snapshot: `mvn deploy -P sisu-release` for testing
 * make sure source code does not have `@since TBD`; of have, search/replace it with upcoming version
 * perform the release
 
-The "usual" Maven release:
-* `mvn release:prepare`
-* `mvn release:perform`
-* project uses <https://oss.sonatype.org/> to stage (manual step: close and release staging repository)
+## Using Njord
+
+This build publishes to Maven Central using [Sonatype Central Portal](https://central.sonatype.com/) service. To accomplish this, build
+uses [Maveniverse Njord](https://github.com/maveniverse/njord) extension. Check out [Njord plugin](https://maveniverse.eu/docs/njord/) documentation as well.
+
+Follow these steps to set up yourself to publish to Central Portal:
+
+1. Using https://central.sonatype.com/account (while logged in) generate tokens for your account.
+2. Edit your settings and add following server entry:
+   ```xml
+   <server>
+      <id>sonatype-cp</id>
+      <username>{tokenusername}</username>
+      <password>{tokenpassword}</password>
+    </server>
+   ```
+   while here, another good change for settings is this:
+   ```xml
+   <pluginGroups>
+     <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
+   </pluginGroups>
+   ```
+3. Perform release "as usual" (execute `mvn release:prepare` followed by `mvn release:perform`)
+4. If build ended OK, you will have locally staged release, use `mvn njord:list` to check store name.
+5. If needed, verify staging content using `mvn njord:list-content -Dstore=$storeName`
+6. If all okay, publish the staged store to Sonatype Central Portal `mvn njord:publish -Dstore=$storeName -Dtarget=sonatype-cp`
 
 ## Site
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,7 +45,7 @@ Follow these steps to set up yourself to publish to Central Portal:
 3. Perform release "as usual" (execute `mvn release:prepare` followed by `mvn release:perform`)
 4. If build ended OK, you will have locally staged release, use `mvn njord:list` to check store name.
 5. If needed, verify staging content using `mvn njord:list-content -Dstore=$storeName`
-6. If all okay, publish the staged store to Sonatype Central Portal `mvn njord:publish -Dstore=$storeName -Dtarget=sonatype-cp`
+6. If all okay, publish the staged store to Sonatype Central Portal `mvn njord:publish` (by default will publish to `sonatype-cp` and will figure out store. If override needed, use `-Dstore=$storeName -Dtarget=sonatype-cp`)
 
 ## Site
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,14 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>njord-snapshots</id>
-      <name>Local Snapshots Staging</name>
-      <url>njord:snapshot-sca</url>
+      <id>sonatype-cp</id>
+      <name>Sonatype Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>njord-releases</id>
-      <name>Local Release Staging</name>
-      <url>njord:release-sca</url>
+      <id>sonatype-cp</id>
+      <name>Sonatype Central Portal</name>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
     <site>
       <id>sisu.site-deploy</id>
@@ -129,9 +129,6 @@
     <asmVersion>9.8</asmVersion>
     <!-- define empty, as jacoco is only conditionally executed (https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html) -->
     <argLine />
-
-    <!-- Publishing happens against Sonatype Central Portal (server.id of same name is needed in your settings.xml) -->
-    <njord.target>sonatype-cp</njord.target>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -94,16 +94,16 @@
   </ciManagement>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-cp</id>
-      <name>Sonatype Central Portal Snapshots</name>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
-    </snapshotRepository>
     <repository>
-      <id>sonatype-cp</id>
+      <id>sonatype-cp-service</id>
       <name>Sonatype Central Portal</name>
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
+    <snapshotRepository>
+      <id>sonatype-cp-service</id>
+      <name>Sonatype Central Portal Snapshots</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+    </snapshotRepository>
     <site>
       <id>sisu.site-deploy</id>
       <url>scm:git:ssh://git@github.com/eclipse-sisu/sisu-website.git</url>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,9 @@
     <asmVersion>9.8</asmVersion>
     <!-- define empty, as jacoco is only conditionally executed (https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html) -->
     <argLine />
+
+    <!-- Publishing happens against Sonatype Central Portal (server.id of same name is needed in your settings.xml) -->
+    <njord.target>sonatype-cp</njord.target>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,14 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>njord-snapshots</id>
+      <name>Local Snapshots Staging</name>
+      <url>njord:snapshot-sca</url>
     </snapshotRepository>
     <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>njord-releases</id>
+      <name>Local Release Staging</name>
+      <url>njord:release-sca</url>
     </repository>
     <site>
       <id>sisu.site-deploy</id>


### PR DESCRIPTION
Makes project independent of any proprietary code and config, uses plain vanilla Maven along with Maveniverse Njord extension that provides local staging and publishing support.

This closes #187