### PR TITLE
Align subproject names (and naming)

### DIFF
--- a/org.eclipse.sisu.inject.extender/pom.xml
+++ b/org.eclipse.sisu.inject.extender/pom.xml
@@ -25,7 +25,8 @@
 
   <artifactId>org.eclipse.sisu.inject.extender</artifactId>
   <packaging>jar</packaging>
-  <name>Eclipse Sisu JSR-330 Extender</name>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Automatically discovers and wires JSR-330 annotated Sisu components contained in OSGi bundles</description>
 
   <build>

--- a/org.eclipse.sisu.inject/pom.xml
+++ b/org.eclipse.sisu.inject/pom.xml
@@ -25,7 +25,8 @@
 
   <artifactId>org.eclipse.sisu.inject</artifactId>
   <packaging>jar</packaging>
-  <name>Eclipse Sisu Container</name>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>JSR330-based container; supports classpath scanning, auto-binding, and dynamic auto-wiring</description>
 
   <dependencies>

--- a/org.eclipse.sisu.mojos/pom.xml
+++ b/org.eclipse.sisu.mojos/pom.xml
@@ -25,7 +25,8 @@
 
   <artifactId>sisu-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Eclipse Sisu Maven Plugin</name>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Maven plugin generating Sisu index files</description>
 
   <prerequisites>

--- a/org.eclipse.sisu.plexus.extender/pom.xml
+++ b/org.eclipse.sisu.plexus.extender/pom.xml
@@ -25,6 +25,8 @@
 
   <artifactId>org.eclipse.sisu.plexus.extender</artifactId>
   <packaging>jar</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Plexus-JSR330 adapter; adds Plexus support to the Sisu-Inject container</description>
 
   <build>

--- a/org.eclipse.sisu.plexus/pom.xml
+++ b/org.eclipse.sisu.plexus/pom.xml
@@ -25,7 +25,8 @@
 
   <artifactId>org.eclipse.sisu.plexus</artifactId>
   <packaging>jar</packaging>
-  <name>Eclipse Sisu Plexus</name>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Plexus-JSR330 adapter; adds Plexus support to the Sisu-Inject container</description>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,9 @@
   <version>0.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Sisu</name>
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Eclipse Sisu: JSR330-based container, Plexus-JSR330 adapter and supporting Maven Mojos</description>
+
   <url>https://eclipse.dev/sisu/</url>
   <inceptionYear>2010</inceptionYear>
   <organization>


### PR DESCRIPTION
Just use G:A for easy navigation, all the fancy "marketing" names are just distraction. Also, naming was inconsistent.