### PR TITLE
Update source header.

### DIFF
--- a/license-header-epl2.txt
+++ b/license-header-epl2.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${year} Sonatype, Inc.
+Copyright (c) ${year} Sonatype, Inc. and others.
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at


### PR DESCRIPTION
Based on:
https://www.eclipse.org/projects/handbook/#ip-copyright-headers

Added the "and others". I personally would go for "more generic" header (see doco above), but then we'd need to author NOTICE file that I am not happy about.

This commit needs to be agreed upon, and reformat can happen only AFTER this PR is merged, as license plugin uses GH raw URL from main branch to get the header.