### PR TITLE
Update TestNG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>6.14.3</version>
+        <version>7.5.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
The used version triggers vulnerability, but the dependency is here only as optional to provide support for tests by using TestNG annotations.