### PR TITLE
Remove "Incubation" from bundle names

### DIFF
--- a/org.eclipse.sisu.inject/bnd.bnd
+++ b/org.eclipse.sisu.inject/bnd.bnd
@@ -1,19 +1,17 @@
-Bundle-Name: Sisu-Inject (Incubation)
+Bundle-Name: Sisu-Inject
 Bundle-SymbolicName: org.eclipse.sisu.inject;singleton:=true
 Main-Class: org.eclipse.sisu.launch.Main
--exportcontents: !*.asm.*,\
- org.eclipse.sisu.*,\
+-exportcontents: org.eclipse.sisu.*,\
  org.sonatype.inject;x-internal:=true
 # remove annotation processor dependencies (never used at runtime)
 # mark all optional dependencies as optional
-Import-Package: javax.inject,\
- org.objectweb.asm.*,\
- com.google.inject.servlet;resolution:=optional,\
+Import-Package: com.google.inject.servlet;resolution:=optional,\
  javax.servlet.*;resolution:=optional,\
  org.slf4j.*;resolution:=optional,\
  org.junit.*;resolution:=optional,\
  junit.framework.*;resolution:=optional,\
  org.testng.*;resolution:=optional,\
+ javax.enterprise.inject;resolution:=optional,\
  !javax.annotation.processing.*,\
  !javax.lang.model.*,\
  !javax.tools.*,\

--- a/org.eclipse.sisu.plexus/bnd.bnd
+++ b/org.eclipse.sisu.plexus/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-Name: Sisu-Plexus (Incubation)
+Bundle-Name: Sisu-Plexus
 Bundle-SymbolicName: org.eclipse.sisu.plexus;singleton:=true
 -exportcontents: org.eclipse.sisu.plexus.*,\
  org.codehaus.plexus.*


### PR DESCRIPTION
Only explicitly mention Import-Packages which deviate from the bnd standard (*)
Remove obsolete export of ASM (no longer contained in the bundle) Make dependency on javax.enterprise.inject optional in OSGi