### PR TITLE
Hide version in site header

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -25,8 +25,8 @@
 -->
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+    <version position="none"/>
     <publishDate position="right"/>
-    <version position="right"/>
     <bannerLeft href="https://eclipse.dev/sisu/">
         <image src="./sisu-black.png" />
     </bannerLeft>


### PR DESCRIPTION
This allows transparent fixes for the website outside release cycles.