### PR TITLE
Possibility to back out from injecting Logger

### DIFF
--- a/org.eclipse.sisu.inject/src/main/java/org/eclipse/sisu/bean/BeanPropertyField.java
+++ b/org.eclipse.sisu.inject/src/main/java/org/eclipse/sisu/bean/BeanPropertyField.java
@@ -16,13 +16,14 @@ import com.google.inject.ProvisionException;
 import com.google.inject.TypeLiteral;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 /**
- * {@link BeanProperty} backed by a {@link Field}.
+ * {@link BeanPropertyGetter} backed by a {@link Field}.
  */
-final class BeanPropertyField<T> implements BeanProperty<T>, PrivilegedAction<Void> {
+final class BeanPropertyField<T> implements BeanPropertyGetter<T>, PrivilegedAction<Void> {
     // ----------------------------------------------------------------------
     // Implementation fields
     // ----------------------------------------------------------------------
@@ -68,6 +69,26 @@ final class BeanPropertyField<T> implements BeanProperty<T>, PrivilegedAction<Vo
 
         try {
             field.set(bean, value);
+        } catch (final LinkageError | Exception e) {
+            throw new ProvisionException("Error injecting: " + field, e);
+        }
+    }
+
+    @Override
+    public boolean isFinal() {
+        return Modifier.isFinal(field.getModifiers());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <B> T get(final B bean) {
+        if (!field.isAccessible()) {
+            // make sure we can get existing value
+            AccessController.doPrivileged(this); // NOSONAR
+        }
+
+        try {
+            return (T) field.get(bean);
         } catch (final LinkageError | Exception e) {
             throw new ProvisionException("Error injecting: " + field, e);
         }

--- a/org.eclipse.sisu.inject/src/main/java/org/eclipse/sisu/bean/BeanPropertyGetter.java
+++ b/org.eclipse.sisu.inject/src/main/java/org/eclipse/sisu/bean/BeanPropertyGetter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026 Sonatype, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Stuart McCulloch (Sonatype, Inc.) - initial API and implementation
+ */
+package org.eclipse.sisu.bean;
+
+/**
+ * Extends {@link BeanProperty} with extra methods, applicable only in case if property is queryable, like
+ * for example when property is backed by a field.
+ *
+ * @since 1.0.1
+ */
+public interface BeanPropertyGetter<T> extends BeanProperty<T> {
+    /**
+     * Tells is the property backing field having {@code final} modifier or not. This can reveal some discrepancies in
+     * legacy vs modern apps (Plexus vs JSR330), as sometimes, the fact this is a final field, but we did create
+     * instance of it, may tell us that injection is not needed even if required. This is most typical for loggers, where
+     * legacy/Plexus components waited for logger to be injected, while modern applications use logger factories like
+     * Slf4j factory is.
+     *
+     * @return true if the field backing property is {@code final}.
+     */
+    boolean isFinal();
+
+    /**
+     * Gets the property in the given bean and returns the value.
+     *
+     * @param bean The bean to update
+     * @return value The bean property value.
+     */
+    <B> T get(final B bean);
+}

--- a/org.eclipse.sisu.plexus/src/main/java/org/eclipse/sisu/plexus/PlexusLifecycleManager.java
+++ b/org.eclipse.sisu.plexus/src/main/java/org/eclipse/sisu/plexus/PlexusLifecycleManager.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Startable;
 import org.eclipse.sisu.bean.BeanManager;
 import org.eclipse.sisu.bean.BeanProperty;
+import org.eclipse.sisu.bean.BeanPropertyGetter;
 import org.eclipse.sisu.bean.BeanScheduler;
 import org.eclipse.sisu.bean.PropertyBinding;
 import org.eclipse.sisu.inject.Logs;
@@ -104,11 +105,20 @@ public final class PlexusLifecycleManager extends BeanScheduler implements BeanM
         final Class clazz = property.getType().getRawType();
         if ("org.slf4j.Logger".equals(clazz.getName())) // NOSONAR
         {
+            // in case of SLF4J logger, and final field, we may want to back-out
+            BeanPropertyGetter getter;
+            if (property instanceof BeanPropertyGetter) {
+                getter = (BeanPropertyGetter) property;
+            } else {
+                getter = null;
+            }
             return new PropertyBinding() {
                 @Override
                 @SuppressWarnings("unchecked")
                 public <B> void injectProperty(final B bean) {
-                    property.set(bean, getSLF4JLogger(bean));
+                    if (null == getter || !getter.isFinal()) {
+                        property.set(bean, getSLF4JLogger(bean));
+                    }
                 }
             };
         }

--- a/org.eclipse.sisu.plexus/src/test/java/org/eclipse/sisu/plexus/PlexusLifecycleManagerTest.java
+++ b/org.eclipse.sisu.plexus/src/test/java/org/eclipse/sisu/plexus/PlexusLifecycleManagerTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2010-present Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Stuart McCulloch (Sonatype, Inc.) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sisu.plexus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.inject.AbstractModule;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This UT tests scenario, where legacy (Plexus) meets modern (JSR330) components. Assume you have a component that
+ * originally was a Plexus component (and Plexus XML still exists somewhere), but the class was migrated to JSR330.
+ * Most specifically, the class used Plexus Logger as requirement and now is migrated to JSR330 and uses Slf4j
+ * logger factory, hence, the logger field became {@code final}. In this single, very special case, Plexus Shim
+ * my opt to not inject the value, given field is final, and we already created bean instance, and it implies
+ * that field was already populated.
+ * This prevents unwanted warnings on Java 26+ where final fields are being modified by Sisu.
+ */
+class PlexusLifecycleManagerTest {
+    @Component(role = Object.class)
+    static class LoggingBean {
+        @Requirement
+        private Logger logger;
+    }
+
+    @Component(role = Object.class)
+    static class OtherLoggingBean {
+        @Requirement
+        private final Logger logger = LoggerFactory.getLogger("other-logging-bean");
+    }
+
+    @Test
+    void testLoggers() throws Exception {
+        PlexusContainer container = createContainer();
+        try {
+            LoggingBean loggingBean = container.lookup(LoggingBean.class);
+            assertNotNull(loggingBean.logger);
+            assertEquals(LoggingBean.class.getName(), loggingBean.logger.getName());
+
+            OtherLoggingBean otherLoggingBean = container.lookup(OtherLoggingBean.class);
+            assertNotNull(otherLoggingBean.logger);
+            assertEquals("other-logging-bean", otherLoggingBean.logger.getName());
+        } finally {
+            container.dispose();
+        }
+    }
+
+    private static PlexusContainer createContainer() throws Exception {
+        final ContainerConfiguration config = new DefaultContainerConfiguration();
+        return new DefaultPlexusContainer(config, new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(LoggingBean.class);
+                bind(OtherLoggingBean.class);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Add ability to Plexus Shim to inspect field in case when SLF4J logger is to be injected, and back out of it, if field is `final`. Given we already have the bean instance created, it means -- at least in case of logger -- that bean may have been migrated off from Plexus.

Still, the question why is the bean, that was migrated away from Plexus to JSR330 still handled by Plexus remains.

---

This is DRAFT on purpose, to start some discussion. Original issue recorded here:
https://github.com/apache/maven/issues/12115
And I cannot imagine any other case, than "new" JSR330 `EventSpyDispatcher` class (Maven 3.10.x migrated fully to JSR330) and old Plexus XML descriptor are somehow both present at the same time in container/classpath. Unsure yet, how. Plexus XML from Maven 3.9.x is this:
```xml
<component>
  <role>org.apache.maven.eventspy.internal.EventSpyDispatcher</role>
  <role-hint>default</role-hint>
  <implementation>org.apache.maven.eventspy.internal.EventSpyDispatcher</implementation>
  <description />
  <isolated-realm>false</isolated-realm>
  <requirements>
    <requirement>
      <role>org.codehaus.plexus.logging.Logger</role>
      <field-name>logger</field-name>
    </requirement>
    <requirement>
      <role>org.apache.maven.eventspy.EventSpy</role>
      <field-name>eventSpies</field-name>
    </requirement>
  </requirements>
</component>
```

And Maven 3.10.x `EventSpyDispatcher` looks like this:
https://github.com/apache/maven/blob/27f7b546886b9d8fd6c7695523bb544db9eeed26/maven-core/src/main/java/org/apache/maven/eventspy/internal/EventSpyDispatcher.java

My theory would also imply, that field `logger` receives `org.slf4j.Logger` instead of declared `role=org.codehaus.plexus.logging.Logger` too, but that to me seems possible, as two logger types in `PlexusLifecycleManager` are special cases.